### PR TITLE
Clear anchor tags in pr-identifiers

### DIFF
--- a/src/slackevents/index.ts
+++ b/src/slackevents/index.ts
@@ -74,7 +74,8 @@ async function handleLinkSharedEvent(
           .split("/")
           .slice(3, 7)
           .join(":")
-          .replace("pull-requests", "pullrequests");
+          .replace("pull-requests", "pullrequests")
+          .replace(/#.*$/, '');
       } catch (e) {
         return undefined;
       }


### PR DESCRIPTION
# Background
I've noticed some PRs not getting event updates and wanted to help do something about it
<img width="529" alt="Screenshot 2023-10-27 at 15 46 06" src="https://github.com/Dr-Horv/HorvBot/assets/1532451/2ae817df-21ec-42dc-bc3e-c7db575bd543">

## Issue
Seems like some people copy the link from some link on github where an anchor-tag is applied, which makes the pr-identifier invalid since it's never removed when building the string here.
